### PR TITLE
Initial docs using API Blueprint

### DIFF
--- a/BLUEPRINT.md
+++ b/BLUEPRINT.md
@@ -128,19 +128,3 @@ Retrieve an incident by its *id*.
               ]
             }
 
-
-# GET /incidents/{id}/reports
-Retrieve all of an incident's reports, identifying the incident by its *id*.
-
-+ Parameters
-
-    + id (required, string, `df34a81e-4fe5-4c09-8403-466526ea503c`) ... Id of an incident.
-
-+ Response 200 (application/json)
-
-  JSON conforming to the GeoJSON spec. Response is a feature collection containing 1 or more features. Each feature represents a report for the requested incident. The features are ordered by *updated* date ascending.
-
-  + Body
-
-            { ... }
-


### PR DESCRIPTION
Initial pass at API docs using [API Blueprint](http://apiblueprint.org). Only covering 2 endpoints for now. Will use this as a guide for developing the API. Intending to use [Aglio](https://github.com/danielgtaylor/aglio) to generate API docs to serve via Github Pages.
